### PR TITLE
Edit expense and income

### DIFF
--- a/server/src/main/java/com/piggy/piggyServer/Cruds/expenses/ExpensesController.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/expenses/ExpensesController.java
@@ -1,6 +1,7 @@
 package com.piggy.piggyServer.Cruds.expenses;
 
 
+import com.piggy.piggyServer.Cruds.income.IncomeEntity;
 import com.piggy.piggyServer.Cruds.user.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -59,6 +60,12 @@ public class ExpensesController {
   public ResponseEntity<?> getExpenseByUserId(@PathVariable Long userId) {
     return expensesService.getExpensesByUserId(userId);
   }
+
+  @PutMapping("/{incomeId}")
+  public ExpensesEntity updateExpense(@PathVariable Long expenseId, @RequestBody ExpensesEntity updateExpense){
+    return expensesService.updateExpense(expenseId, updateExpense);
+  }
+
   @DeleteMapping("{expenseId}")
   public ResponseEntity<?> deleteByExpenseId(@PathVariable Long expenseId){
     return expensesService.deleteExpenseById(expenseId);

--- a/server/src/main/java/com/piggy/piggyServer/Cruds/expenses/ExpensesService.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/expenses/ExpensesService.java
@@ -66,11 +66,19 @@ public class ExpensesService {
     return ResponseEntity.ok(userExpense);
   }
 
-  public ExpensesEntity updateExpense(Long expenseId, ExpensesEntity updateExpense){
-    ExpensesEntity expense = expensesRepository.findById(expenseId).orElseThrow(() -> new IllegalArgumentException("Income not found"));
-    expense.setName(updateExpense.getName());
-    expense.setDate(updateExpense.getDate());
-    expense.setAmount(updateExpense.getAmount());
+  public ExpensesEntity updateExpense(Long expenseId, ExpensesEntity updateExpense) {
+    ExpensesEntity expense = expensesRepository.findById(expenseId)
+        .orElseThrow(() -> new IllegalArgumentException("Income not found"));
+
+    if (updateExpense.getName() != null && !updateExpense.getName().isEmpty()) {
+      expense.setName(updateExpense.getName());
+    }
+    if (updateExpense.getDate() != null) {
+      expense.setDate(updateExpense.getDate());
+    }
+    if (updateExpense.getAmount() != null && updateExpense.getAmount() > 0) {
+      expense.setAmount(updateExpense.getAmount());
+    }
 
     return expensesRepository.save(expense);
   }

--- a/server/src/main/java/com/piggy/piggyServer/Cruds/expenses/ExpensesService.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/expenses/ExpensesService.java
@@ -1,5 +1,6 @@
 package com.piggy.piggyServer.Cruds.expenses;
 
+import com.piggy.piggyServer.Cruds.income.IncomeEntity;
 import com.piggy.piggyServer.Cruds.user.UserEntity;
 import com.piggy.piggyServer.Cruds.user.UserRepository;
 import com.piggy.piggyServer.Cruds.user.UserService;
@@ -63,6 +64,15 @@ public class ExpensesService {
       ));
     }
     return ResponseEntity.ok(userExpense);
+  }
+
+  public ExpensesEntity updateExpense(Long expenseId, ExpensesEntity updateExpense){
+    ExpensesEntity expense = expensesRepository.findById(expenseId).orElseThrow(() -> new IllegalArgumentException("Income not found"));
+    expense.setName(updateExpense.getName());
+    expense.setDate(updateExpense.getDate());
+    expense.setAmount(updateExpense.getAmount());
+
+    return expensesRepository.save(expense);
   }
 
   public ResponseEntity<?> deleteExpenseById(Long expenseId) {

--- a/server/src/main/java/com/piggy/piggyServer/Cruds/goals/GoalService.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/goals/GoalService.java
@@ -69,7 +69,7 @@ public class GoalService {
 
   public GoalsEntity updateGoal(Long goalId, GoalsEntity updatedGoal) {
     GoalsEntity existingGoal = goalRepository.findById(goalId)
-        .orElseThrow(() -> new RuntimeException("Goal not found"));
+        .orElseThrow(() -> new IllegalArgumentException("Goal not found"));
     existingGoal.setGoalName(updatedGoal.getGoalName());
     existingGoal.setSavedAmount(updatedGoal.getSavedAmount());
     existingGoal.setGoalAmount(updatedGoal.getGoalAmount());

--- a/server/src/main/java/com/piggy/piggyServer/Cruds/income/IncomeController.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/income/IncomeController.java
@@ -58,6 +58,11 @@ public class IncomeController {
     return incomeService.getIncomesByUserId(userId);
   }
 
+  @PutMapping("/{incomeId}")
+  public IncomeEntity updateIncome(@PathVariable Long incomeId, @RequestBody IncomeEntity updateIncome){
+    return incomeService.updateIncome(incomeId, updateIncome);
+  }
+
   @DeleteMapping("{incomeId}")
   public ResponseEntity<?> deleteByIncomeId(@PathVariable Long incomeId){
     return incomeService.deleteIncomeById(incomeId);

--- a/server/src/main/java/com/piggy/piggyServer/Cruds/income/IncomeService.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/income/IncomeService.java
@@ -69,10 +69,17 @@ public class IncomeService {
   }
 
   public IncomeEntity updateIncome(Long incomeId, IncomeEntity updateIncome){
-    IncomeEntity income = incomeRepository.findById(incomeId).orElseThrow(() -> new IllegalArgumentException("Income not found"));
-    income.setName(updateIncome.getName());
-    income.setDate(updateIncome.getDate());
-    income.setAmount(updateIncome.getAmount());
+    IncomeEntity income = incomeRepository.findById(incomeId).orElseThrow(() -> new IllegalArgumentException("Expense not found"));
+
+    if (updateIncome.getName() != null && !updateIncome.getName().isEmpty()) {
+      income.setName(updateIncome.getName());
+    }
+    if (updateIncome.getDate() != null) {
+      income.setDate(updateIncome.getDate());
+    }
+    if (updateIncome.getAmount() != null && updateIncome.getAmount() > 0) {
+      income.setAmount(updateIncome.getAmount());
+    }
 
     return incomeRepository.save(income);
   }

--- a/server/src/main/java/com/piggy/piggyServer/Cruds/income/IncomeService.java
+++ b/server/src/main/java/com/piggy/piggyServer/Cruds/income/IncomeService.java
@@ -68,6 +68,15 @@ public class IncomeService {
     return ResponseEntity.ok(userIncomes);
   }
 
+  public IncomeEntity updateIncome(Long incomeId, IncomeEntity updateIncome){
+    IncomeEntity income = incomeRepository.findById(incomeId).orElseThrow(() -> new IllegalArgumentException("Income not found"));
+    income.setName(updateIncome.getName());
+    income.setDate(updateIncome.getDate());
+    income.setAmount(updateIncome.getAmount());
+
+    return incomeRepository.save(income);
+  }
+
   //"?": tipo de respuesta flexible, puede ser cualquiera
   public ResponseEntity<?> deleteIncomeById(Long incomeId) {
     if (!incomeRepository.existsById(incomeId)) {


### PR DESCRIPTION
# Logica edit gastos e ingresos
Se agregó la logica para editar los datos de las gastos y los ingresos por medio de una solicitud **PUT** y la ruta http://localhost:8080/income/3 o http://localhost:8080/expense/3, en donde "3" es el id del gasto o ingreso a modificar.
💡No es necesario editar todos los campos, ya que si dejas algunos campos sin editar mantendrá los datos que tenia antes.

---

### Ejemplo

```json
{
 "name": "torta",
 "date": "2024-12-30T00:00:00Z",
 "amount": 1000
}
```
o simplemente edita el que necesitas

```json
{
 "name": "torta"
}
```
